### PR TITLE
Todos: inference options to AIG, use AIG in EIG

### DIFF
--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -47,12 +47,16 @@ var AIG = function(args) {
         x = args.x,
         y = args.y;
 
-    // TODO: make inference an argument here
-    var mPrior = Enumerate(function() {
+    var infer = args.infer || {},
+        // No inferX or inferY since data is given
+        inferM1 = infer.M1 || Enumerate,
+        inferM2 = infer.M2 || Enumerate;
+
+    var mPrior = inferM1(function() {
         return mNameSample()
     });
 
-    var mPosterior = Enumerate(function() {
+    var mPosterior = inferM2(function() {
         var mName = mNameSample(), m = mFuncs[mName];
         var LL = m(x,y);
         factor(LL);


### PR DESCRIPTION
I was writing some OED stuff which ended up modifying AIG/EIG according to Long's TODOs, so I decided to make a PR here.

One concern might be having to recreate an args object in EIG when handing off control to AIG, since the args dict for AIG needs a specific x and y. Not sure how expensive that is.

In terms of testing, I just diffed the output of the coin example across the changes I made, and the output was identical, but I haven't done anything else.
