### PR TITLE
Add Model and Models wrapper for named funcs

### DIFF
--- a/examples/coin.wppl
+++ b/examples/coin.wppl
@@ -54,23 +54,21 @@ var markovCoin = function(sequence) {
 }
 
 
-var fairSingle = cache(function(sequence) {
+// TODO: in webppl, make sure cache() preserves names
+var fairSingle = Model('fairSingle', cache(function(sequence) {
     Enumerate(function() {
         return flip()
     })
-});
-// TODO: in webppl, make sure cache() preserves names
-Object.defineProperty(fairSingle, 'name', {value: 'fairSingle'})
+}));
 
-var biasSingle = cache(function(sequence) {
+var biasSingle = Model('biasSingle', cache(function(sequence) {
     Enumerate(function() {
         var p = uniformDraw(coinWeights);
         var sampled = repeat(sequence.length, function() { flip(p) })
         condition(arraysEqual(sampled, sequence))
         return flip(p);
     })
-});
-Object.defineProperty(biasSingle, 'name', {value: 'biasSingle'})
+}));
 
 var groupify = function(m) {
     // maybe discriminative m should be of type ((x -> y) -> R) ?
@@ -80,11 +78,10 @@ var groupify = function(m) {
         var p = Math.exp(yDist.score(true));
         return Binomial({n: x.n, p: p}).score(y)
     }
-    Object.defineProperty(gm, 'name', {value: m.name.replace('Single', 'Group')})
-    return gm;
+    return Model(m.name.replace('Single', 'Group'), gm);
 }
 
-var fairGroup = groupify(fairSingle)
+var fairGroup = groupify(fairSingle);
 var biasGroup = groupify(biasSingle);
 
 //sample(biasGroup({n: 20, sequence: [true,true,true,true] }))

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -25,6 +25,18 @@ var variance = function(erp) {
             erp.support()))
 }
 
+var Model = function(name, f) {
+    Object.defineProperty(f, 'name', {value: name})
+    return f;
+};
+
+// Given a name: thunk object, Models will name each function
+var Models = function(obj) {
+    return map(function(key) {
+        return Model(key, obj[key]);
+    }, Object.keys(obj));
+};
+
 // TODO: using this on priors and posteriors Just Works when the supports
 // are {name: ..., func: ...} objects, which is a little surprising
 // figure out why this works


### PR DESCRIPTION
These might be easier than `Object.defineProperty(thunk, 'name', value: {'thunk name'})`...

`Model` lets you write

```
Model('fairSingle', function(sequence) { ... });
```

`Models` lets you write

```
Models({
    m1: function(sequence) { ... },
    m2: function(sequence) { ... },
    ...
})
```
