### PR TITLE
Additional EIG methods and functionality

### DIFF
--- a/examples/coin.wppl
+++ b/examples/coin.wppl
@@ -89,14 +89,17 @@ var nullGroup = Model('nullGroup', function(x, y) {
     return RandomInteger({n: 20 + 1}).score(y);
 });
 
-AIG({
-    M: function() { uniformDraw([fairGroup, biasGroup, markovGroup]) },
-    x: {n: 20, sequence: [true,false,false,true]},
-    y: 3
-})
-
-// EIG({
-    // M: function() { uniformDraw([fairGroup, biasGroup, markovGroup, nullGroup]) },
-    // X: function() { return {n: 20, sequence: repeat(4, flip) } },
-    // Y: function() { randomInteger(20 + 1) }
+// AIG({
+    // M: function() { uniformDraw([fairGroup, biasGroup, markovGroup]) },
+    // x: {n: 20, sequence: [true,false,false,true]},
+    // y: 3
 // })
+
+var EIGdist = EIG({
+    M: function() { uniformDraw([fairGroup, biasGroup, markovGroup, nullGroup]) },
+    X: function() { return {n: 20, sequence: repeat(4, flip) } },
+    Y: function() { randomInteger(20 + 1) }
+});
+
+console.log(EIGdist);
+getBestExpt(EIGdist.support());

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -73,7 +73,7 @@ var AIG = function(args) {
     var infer = args.infer || {};
     var inferM1 = infer.M1 || Enumerate;
     var inferM2 = infer.M2 || Enumerate;
-    var mPrior = inferM1(function() {
+    var mPrior = args.mPrior || inferM1(function() {
         var m = M();
         return {name: m.name, func: m};
     });
@@ -99,18 +99,13 @@ var EIG = function(args) {
         mFuncs = args.mFuncs,
         usePredictiveY = !!args.usePredictiveY;
 
-    // For some reason, I can't refer to args.mNameSample when calling?
-    var mPrior = args.mPrior || (function() {
-        var M = args.M;
-        return inferM1(function() {
-            var m = M();
-            return {name: m.name, func: m};
-        });
-    })();
-
-    var mNameSample = args.mNameSample || function() {
-        return sample(mPrior);
-    };
+    // Construct mPrior either 1) if it's provided in args, or 2) from the
+    // model sample function. Note that args.mPrior overrides args.M if both
+    // are present
+    var mPrior = args.mPrior || inferM1(function() {
+        var m = M();
+        return {name: m.name, func: m};
+    });
 
     inferX(function() {
         var x = X();
@@ -147,7 +142,7 @@ var EIG = function(args) {
 var OED = EIG;
 
 var updatePosterior = function(args) {
-    var mFuncs = args.mFuncs,
+    var M = args.M,
         x = args.x,
         y = args.y;
 
@@ -156,41 +151,20 @@ var updatePosterior = function(args) {
         inferM1 = infer.M1 || Enumerate,
         inferM2 = infer.M2 || Enumerate;
 
-    var mPrior = args.mPrior || (function() {
-        var mNamesample = args.mNameSample;
-        return inferM1(function() {
-            return mNameSample();
-        });
-    })();
-
-    var mNameSample = args.mNameSample || function() {
-        return sample(mPrior);
-    };
+    var mPrior = args.mPrior || inferM1(function() {
+        var m = M();
+        return {name: m.name, func: m};
+    });
 
     var mPosterior = inferM2(function() {
-        var mName = mNameSample(), m = mFuncs[mName];
-        var LL = m(x,y);
+        var mData = sample(mPrior), mName = mData.name, mFunc = mData.func;
+        var LL = mFunc(x,y);
         factor(LL);
-        return mName;
+        return mData;
     });
 
     return {
         mPosterior: mPosterior,
         AIG: KL(mPosterior, mPrior)
     };
-};
-
-var maxEIG = function(args) {
-    // Return the experiment with the maximum EIG.
-    // Args should have a mPrior instead of mNameSample to save computation
-    // time.
-    var EIGdist = EIG(args);
-
-    // Get the experiment with the max EIG
-    return reduce(function(expt, currMax) {
-        if (expt.EIG > currMax.EIG) {
-            return expt;
-        }
-        return currMax;
-    }, {x: null, EIG: 0}, EIGdist.support());
 };

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -46,6 +46,12 @@ var Models = function(obj) {
     }, Object.keys(obj));
 };
 
+var getBestExpt = function(expts) {
+    return reduce(function(expt, currMax) {
+        return (expt.EIG > currMax.EIG) ? expt : currMax;
+    }, {x: null, EIG: -Infinity}, expts);
+};
+
 // TODO: using this on priors and posteriors Just Works when the supports
 // are {name: ..., func: ...} objects, which is a little surprising
 // figure out why this works

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -87,6 +87,7 @@ var AIG = function(args) {
 
     return KL(mPosterior, mPrior);
 }
+
 // notes: doesn't seem to work with incrementalMH right now
 var EIG = function(args) {
     var M = args.M, X = args.X, Y = args.Y;
@@ -97,7 +98,8 @@ var EIG = function(args) {
         inferM1 = infer.M1 || Enumerate,
         inferM2 = infer.M2 || Enumerate,
         mFuncs = args.mFuncs,
-        usePredictiveY = !!args.usePredictiveY;
+        usePredictiveY = !!args.usePredictiveY,
+        returnKL = !!args.returnKL;
 
     // Construct mPrior either 1) if it's provided in args, or 2) from the
     // model sample function. Note that args.mPrior overrides args.M if both
@@ -111,8 +113,6 @@ var EIG = function(args) {
         var x = X();
         // wrt the above distribution on responses, what is the posterior distribution on models?
         var KLDist = inferY(function() {
-            // TODO: What happens if you sample from the updated prior - does
-            // this mix ySample and predictiveY?
             var y = Y();
             if (args.usePredictiveY) {
                 var _m = sample(mPrior), mName = _m.name, mFunc = _m.func;
@@ -126,16 +126,15 @@ var EIG = function(args) {
                 return _m2;
             });
             var kl = KL(mPosterior, mPrior);
-            return {y: y, val: kl};
+            return (returnKL) ? {y: y, val: kl} : kl;
         });
 
         // is there a way of getting confidence intervals around eig?
-        // Note expectation2 since our return values from inferY are objects
-        var EIG = expectation2(KLDist);
+        var EIG = (returnKL) ? expectation2(KLDist) : expectation(KLDist);
         factor(EIG);
         // var VIG = variance(KLDist);
         // return {x: x, EIG: EIG, VIG: VIG}
-        return {x: x, EIG: EIG, KLDist: KLDist}
+        return (returnKL) ? {x: x, EIG: EIG, KLDist: KLDist} : {x: x, EIG: EIG}
     })
 }
 

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -64,15 +64,15 @@ var KL = function(P, Q) {
         statesP));
 }
 
-// compute actual information gain
-var AIG = function(args) {
+var updatePosterior = function(args) {
     var M = args.M,
         x = args.x,
         y = args.y;
 
-    var infer = args.infer || {};
-    var inferM1 = infer.M1 || Enumerate;
-    var inferM2 = infer.M2 || Enumerate;
+    var infer = args.infer || {},
+        inferM1 = infer.M1 || Enumerate,
+        inferM2 = infer.M2 || Enumerate;
+
     var mPrior = args.mPrior || inferM1(function() {
         var m = M();
         return {name: m.name, func: m};
@@ -85,8 +85,16 @@ var AIG = function(args) {
         return mData;
     });
 
-    return KL(mPosterior, mPrior);
-}
+    return {
+        mPosterior: mPosterior,
+        AIG: KL(mPosterior, mPrior)
+    };
+};
+
+// compute actual information gain
+var AIG = function(args) {
+    return updatePosterior(args).AIG;
+};
 
 // notes: doesn't seem to work with incrementalMH right now
 var EIG = function(args) {
@@ -139,31 +147,3 @@ var EIG = function(args) {
 }
 
 var OED = EIG;
-
-var updatePosterior = function(args) {
-    var M = args.M,
-        x = args.x,
-        y = args.y;
-
-    var infer = args.infer || {},
-        // No inferX or inferY since data is given
-        inferM1 = infer.M1 || Enumerate,
-        inferM2 = infer.M2 || Enumerate;
-
-    var mPrior = args.mPrior || inferM1(function() {
-        var m = M();
-        return {name: m.name, func: m};
-    });
-
-    var mPosterior = inferM2(function() {
-        var mData = sample(mPrior), mName = mData.name, mFunc = mData.func;
-        var LL = mFunc(x,y);
-        factor(LL);
-        return mData;
-    });
-
-    return {
-        mPosterior: mPosterior,
-        AIG: KL(mPosterior, mPrior)
-    };
-};

--- a/src/oed.wppl
+++ b/src/oed.wppl
@@ -18,6 +18,15 @@ var expectation = function(erp) {
             erp.support()))
 }
 
+// This does not assume numerical support values. It can accept any object as
+// long as it has a 'val' field from which the expectation will be computed.
+// This allows including additional information in the return values of a
+// computation
+var expectation2 = function(erp) {
+    sum(map(function(state) { return exp(score(erp, state)) * state.val },
+            erp.support()))
+}
+
 var variance = function(erp) {
     var mean = expectation(erp)
 
@@ -78,8 +87,6 @@ var AIG = function(args) {
 
     return KL(mPosterior, mPrior);
 }
-
-
 // notes: doesn't seem to work with incrementalMH right now
 var EIG = function(args) {
     var M = args.M, X = args.X, Y = args.Y;
@@ -92,15 +99,25 @@ var EIG = function(args) {
         mFuncs = args.mFuncs,
         usePredictiveY = !!args.usePredictiveY;
 
-    var mPrior = inferM1(function() {
-        var m = M();
-        return {name: m.name, func: m}
-    });
+    // For some reason, I can't refer to args.mNameSample when calling?
+    var mPrior = args.mPrior || (function() {
+        var M = args.M;
+        return inferM1(function() {
+            var m = M();
+            return {name: m.name, func: m};
+        });
+    })();
+
+    var mNameSample = args.mNameSample || function() {
+        return sample(mPrior);
+    };
 
     inferX(function() {
         var x = X();
         // wrt the above distribution on responses, what is the posterior distribution on models?
         var KLDist = inferY(function() {
+            // TODO: What happens if you sample from the updated prior - does
+            // this mix ySample and predictiveY?
             var y = Y();
             if (args.usePredictiveY) {
                 var _m = sample(mPrior), mName = _m.name, mFunc = _m.func;
@@ -114,16 +131,66 @@ var EIG = function(args) {
                 return _m2;
             });
             var kl = KL(mPosterior, mPrior);
-            return kl;
+            return {y: y, val: kl};
         });
 
         // is there a way of getting confidence intervals around eig?
-        var EIG = expectation(KLDist);
+        // Note expectation2 since our return values from inferY are objects
+        var EIG = expectation2(KLDist);
         factor(EIG);
         // var VIG = variance(KLDist);
         // return {x: x, EIG: EIG, VIG: VIG}
-        return {x: x, EIG: EIG}
+        return {x: x, EIG: EIG, KLDist: KLDist}
     })
 }
 
 var OED = EIG;
+
+var updatePosterior = function(args) {
+    var mFuncs = args.mFuncs,
+        x = args.x,
+        y = args.y;
+
+    var infer = args.infer || {},
+        // No inferX or inferY since data is given
+        inferM1 = infer.M1 || Enumerate,
+        inferM2 = infer.M2 || Enumerate;
+
+    var mPrior = args.mPrior || (function() {
+        var mNamesample = args.mNameSample;
+        return inferM1(function() {
+            return mNameSample();
+        });
+    })();
+
+    var mNameSample = args.mNameSample || function() {
+        return sample(mPrior);
+    };
+
+    var mPosterior = inferM2(function() {
+        var mName = mNameSample(), m = mFuncs[mName];
+        var LL = m(x,y);
+        factor(LL);
+        return mName;
+    });
+
+    return {
+        mPosterior: mPosterior,
+        AIG: KL(mPosterior, mPrior)
+    };
+};
+
+var maxEIG = function(args) {
+    // Return the experiment with the maximum EIG.
+    // Args should have a mPrior instead of mNameSample to save computation
+    // time.
+    var EIGdist = EIG(args);
+
+    // Get the experiment with the max EIG
+    return reduce(function(expt, currMax) {
+        if (expt.EIG > currMax.EIG) {
+            return expt;
+        }
+        return currMax;
+    }, {x: null, EIG: 0}, EIGdist.support());
+};


### PR DESCRIPTION
Changes:
- An `updatePosterior` method, which is needed for adaptive AOED. Like AIG, but returns the updated model posterior
- `AIG`, `EIG`, `updatePosterior` accepts an optional `mPrior` argument which, if specified, overrides the `M` sample function
- `EIG` has a `returnKL` option, which returns the KL distribution (with actual AIG values for each experiment response) for the experiments. I needed this for constructing the AIG curves in the coin plots I made previously; I think it could be extra useful diagnostic information. However, I'm open to ideas about whether or not it belongs here, or perhaps in a separate function; the boolean flag requires inserting control flow into several spots in the `EIG` function, which might not be desirable. Also requires a second expectation function
